### PR TITLE
Enable keep-alive when talking to the backing node

### DIFF
--- a/rpc.ts
+++ b/rpc.ts
@@ -24,6 +24,18 @@ export class RpcClient {
         } else {
             rpc = new _rpcClient(connectionString, { maxRetries: 0 });
             rpc_retry = new _rpcClient(connectionString, { maxRetries: Config.rpc.rpcMaxRetries, timeoutMs: Config.rpc.rpcTimeoutMs, retryDelayMs: Config.rpc.rpcRetryDelayMs });
+            // Hack: overide the underlying protocol to reuse connections
+            // The underlying library allows specifying custom options for the client, re: https://github.com/bitpay/bitcoind-rpc/blob/96257629cfa36f9e1a36500f69d209cdc3cba0a7/lib/index.js#L85-L89
+            // Here we enforce the usage of our own agent which has keep-alive enabled.
+            if (!rpc.httpOptions) {
+                rpc.httpOptions = {}
+            }
+            rpc.httpOptions.agent = new rpc.protocol.Agent({keepAlive: true})
+            if (!rpc_retry.httpOptions) {
+                rpc_retry.httpOptions = {}
+            }
+            rpc_retry.httpOptions.agent = new rpc_retry.protocol.Agent({keepAlive: true})
+
         }
     }
 


### PR DESCRIPTION
With keep alive in place, I observe

- nodejs CPU load while indexing testnet went from ~90% to ~25%
- dockerd's CPU load went from ~30% to ~15%
- Network sockets on bch node in TIME_WAIT state went from ~14,000 to 0 (sockets stuck in TIME_WAIT is bad because if all ephimeral ports are used up then slpdb will have an error trying to connect to the node)